### PR TITLE
Rework #146. Fixes various errors relating to input length.

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -101,6 +101,12 @@ func (r *Runner) Run() error {
 
 	br := bufio.NewScanner(inFile)
 
+	if r.options.CharLimit > bufio.MaxScanTokenSize {
+		// Satisfy the condition of our splitters, which is that charLimit is <= the size of the bufio.Scanner buffer
+		buffer := make([]byte, 0, r.options.CharLimit)
+		br.Buffer(buffer, r.options.CharLimit)
+	}
+
 	if r.options.Bulk {
 		splitter, err = bulkSplitter(r.options.CharLimit)
 	} else {

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"bufio"
 	"crypto/tls"
-	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -129,7 +128,7 @@ func (r *Runner) Run() error {
 
 func (r *Runner) sendMessage(msg string) error {
 	if len(msg) > 0 {
-		fmt.Println(msg)
+		gologger.Silent().Msgf("%s\n", msg)
 		err := r.providers.Send(msg)
 		if err != nil {
 			return err

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -101,6 +101,8 @@ func (r *Runner) Run() error {
 	br := bufio.NewScanner(inFile)
 	if r.options.Bulk {
 		br.Split(bulkSplitter(r.options.CharLimit))
+	} else {
+		br.Split(lineLengthSplitter(r.options.CharLimit))
 	}
 	for br.Scan() {
 		msg := br.Text()

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -85,6 +85,7 @@ func (r *Runner) Run() error {
 
 	var inFile *os.File
 	var err error
+	var splitter bufio.SplitFunc
 
 	switch {
 	case r.options.Data != "":
@@ -99,11 +100,19 @@ func (r *Runner) Run() error {
 	}
 
 	br := bufio.NewScanner(inFile)
+
 	if r.options.Bulk {
-		br.Split(bulkSplitter(r.options.CharLimit))
+		splitter, err = bulkSplitter(r.options.CharLimit)
 	} else {
-		br.Split(lineLengthSplitter(r.options.CharLimit))
+		splitter, err = lineLengthSplitter(r.options.CharLimit)
 	}
+
+	if err != nil {
+		return err
+	}
+
+	br.Split(splitter)
+
 	for br.Scan() {
 		msg := br.Text()
 		//nolint:errcheck

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"bufio"
 	"crypto/tls"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -111,7 +112,7 @@ func (r *Runner) Run() error {
 
 func (r *Runner) sendMessage(msg string) error {
 	if len(msg) > 0 {
-		gologger.Print().Msgf("%s\n", msg)
+		fmt.Println(msg)
 		err := r.providers.Send(msg)
 		if err != nil {
 			return err

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -97,31 +97,14 @@ func (r *Runner) Run() error {
 		return errors.New("notify works with stdin or file using -data flag")
 	}
 
-	info, err := inFile.Stat()
-	if err != nil {
-		return errors.Wrap(err, "could not get file info")
-	}
 	br := bufio.NewScanner(inFile)
-	maxSize := int(info.Size())
-	buffer := make([]byte, 0, maxSize)
-	br.Buffer(buffer, maxSize)
-
 	if r.options.Bulk {
 		br.Split(bulkSplitter(r.options.CharLimit))
 	}
 	for br.Scan() {
 		msg := br.Text()
-		if len(msg) > r.options.CharLimit {
-			// send the msg in chunks of length charLimit
-			for _, chunk := range SplitInChunks(msg, r.options.CharLimit) {
-				//nolint:errcheck
-				r.sendMessage(chunk)
-			}
-		} else {
-			//nolint:errcheck
-			r.sendMessage(msg)
-		}
-
+		//nolint:errcheck
+		r.sendMessage(msg)
 	}
 	return nil
 }

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -109,7 +109,7 @@ func (r *Runner) Run() error {
 		//nolint:errcheck
 		r.sendMessage(msg)
 	}
-	return nil
+	return br.Err()
 }
 
 func (r *Runner) sendMessage(msg string) error {

--- a/internal/runner/util.go
+++ b/internal/runner/util.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"bufio"
-	"math"
 )
 
 var ellipsis = []byte("...")
@@ -55,22 +54,4 @@ func bulkSplitter(charLimit int) bufio.SplitFunc {
 		}
 		return
 	}
-}
-
-// SplitInChunks splits a string into chunks of size charLimit
-func SplitInChunks(data string, charLimit int) []string {
-	length := len(data)
-	noOfChunks := int(math.Ceil(float64(length) / float64(charLimit)))
-	chunks := make([]string, noOfChunks)
-	var start, stop int
-
-	for i := 0; i < noOfChunks; i += 1 {
-		start = i * charLimit
-		stop = start + charLimit
-		if stop > length {
-			stop = length
-		}
-		chunks[i] = data[start:stop]
-	}
-	return chunks
 }

--- a/internal/runner/util.go
+++ b/internal/runner/util.go
@@ -2,13 +2,17 @@ package runner
 
 import (
 	"bufio"
+	"fmt"
 )
 
 var ellipsis = []byte("...")
 
 // Return a bufio.SplitFunc that splits on as few newlines as possible
 // while giving as many bytes that are <= charLimit each time
-func bulkSplitter(charLimit int) bufio.SplitFunc {
+func bulkSplitter(charLimit int) (bufio.SplitFunc, error) {
+	if charLimit <= len(ellipsis) {
+		return nil, fmt.Errorf("charLimit must be > %d", len(ellipsis))
+	}
 	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		var lineAdvance int
 		var line []byte
@@ -54,12 +58,15 @@ func bulkSplitter(charLimit int) bufio.SplitFunc {
 			token = token[:len(token)-1]
 		}
 		return
-	}
+	}, nil
 }
 
 // Return a bufio.SplitFunc that splits on all newlines
 // while giving as many bytes that are <= charLimit each time
-func lineLengthSplitter(charLimit int) bufio.SplitFunc {
+func lineLengthSplitter(charLimit int) (bufio.SplitFunc, error) {
+	if charLimit <= len(ellipsis) {
+		return nil, fmt.Errorf("charLimit must be > %d", len(ellipsis))
+	}
 	return func(data []byte, atEOF bool) (advance int, token []byte, err error) {
 		var line []byte
 
@@ -80,5 +87,5 @@ func lineLengthSplitter(charLimit int) bufio.SplitFunc {
 		}
 
 		return advance, line, err
-	}
+	}, nil
 }


### PR DESCRIPTION
Reverts/reworks #146 with IMO a more correct approach that doesn't involve resizing the Scanner's buffer based on the size of the input (which fails if input is stdin)

Fixes/obsoletes #148 and #149

Fixes #134 by emitting logged lines to stdout instead of stderr. I had tried to fix this in #130 but it got reverted during the merge. If #134 isn't a bug, or this isn't the right way to fix the bug, please revert the commit.

Fixes a crash or infinite loop where -char-limit is less than the length of the ellipsis we use to indicated truncated lines (thanks to https://github.com/projectdiscovery/notify/pull/149#pullrequestreview-1003490705 for catching this). There's no open issue for this, but here's a repro:

```
% git checkout b947254064e6c09d18b56e1064cbcbabb0e21e72
HEAD is now at b947254 chore(deps): bump golang from 1.18.2-alpine to 1.18.3-alpine (#144)

% go build .

% id | ./notify -cl 2 -bulk

             __  _ ___
  ___  ___  / /_(_) _/_ __
 / _ \/ _ \/ __/ / _/ // /
/_//_/\___/\__/_/_/ \_, / v1.0.2-dev
                   /___/

                projectdiscovery.io

Use with caution. You are responsible for your actions
Developers assume no liability and are not responsible for any misuse or damage.
Using default provider config: /home/justin/.config/notify/provider-config.yaml
panic: runtime error: slice bounds out of range [:-1]

goroutine 1 [running]:
github.com/projectdiscovery/notify/internal/runner.bulkSplitter.func1({0xc00014f000, 0x51, 0x1000}, 0x0)
        /home/justin/opt/notify/internal/runner/util.go:35 +0x389
bufio.(*Scanner).Scan(0xc00021fe28)
        /usr/local/go/src/bufio/scan.go:147 +0xbf
github.com/projectdiscovery/notify/internal/runner.(*Runner).Run(0xc000277060)
        /home/justin/opt/notify/internal/runner/runner.go:104 +0x5e5
main.main()
        /home/justin/opt/notify/cmd/notify/notify.go:42 +0x1b1

% id | ./notify -cl 3 -bulk

             __  _ ___
  ___  ___  / /_(_) _/_ __
 / _ \/ _ \/ __/ / _/ // /
/_//_/\___/\__/_/_/ \_, / v1.0.2-dev
                   /___/

                projectdiscovery.io

Use with caution. You are responsible for your actions
Developers assume no liability and are not responsible for any misuse or damage.
Using default provider config: /home/justin/.config/notify/provider-config.yaml
...
...
...
...
...
...
...
...
...
...
- Ctrl+C pressed in Terminal
```

Fixes #137 by adding a `bufio.SplitFunc` to split long lines in non-bulk mode

Finally, fixes #146 by never allowing the Scanner's buffer to fill.

# Testing

## Test cases

```
% cat test.sh
#!/bin/bash

cd $(dirname "$(readlink -f "$0")")

heading() {
    echo "[+] $1"
}

provider_invalid_webhook=provider-invalid-webhook.yaml
provider_discord=provider-discord.yaml
provider_slack=provider-slack.yaml

heading /etc/passwd
cmp <(./notify -provider-config $provider_invalid_webhook -silent -bulk -i /etc/passwd) \
    <(cat /etc/passwd) && echo matches
cmp <(./notify -provider-config $provider_invalid_webhook -silent -i /etc/passwd) \
    <(cat /etc/passwd) && echo matches

heading /dev/null
cmp <(./notify -provider-config $provider_invalid_webhook -silent -bulk -i /dev/null) \
    <(cat /dev/null) && echo matches
cmp <(./notify -provider-config $provider_invalid_webhook -silent -i /dev/null) \
    <(cat /dev/null) && echo matches

heading 'A*6 with -char-limit=3 (Expect errors)'
echo AAAAAA | ./notify -provider-config $provider_invalid_webhook -silent -bulk -char-limit 3
echo AAAAAA | ./notify -provider-config $provider_invalid_webhook -silent -char-limit 3
heading 'A*6 with -char-limit=4'
echo AAAAAA | ./notify -provider-config $provider_invalid_webhook -silent -char-limit 4
echo AAAAAA | ./notify -provider-config $provider_invalid_webhook -silent -bulk -char-limit 4

heading 'A*2048'
cmp <(python3 -c'print("A"*2048)' | ./notify -provider-config $provider_invalid_webhook -silent -bulk) \
    <(python3 -c'print("A"*2048)') && echo matches
cmp <(python3 -c'print("A"*2048)' | ./notify -provider-config $provider_invalid_webhook -silent) \
    <(python3 -c'print("A"*2048)') && echo matches

heading 'A*3999'
cmp <(python3 -c'print("A"*3999)' | ./notify -provider-config $provider_invalid_webhook -silent -bulk) \
    <(python3 -c'print("A"*3999)') && echo matches
cmp <(python3 -c'print("A"*3999)' | ./notify -provider-config $provider_invalid_webhook -silent) \
    <(python3 -c'print("A"*3999)') && echo matches

heading 'A*4000'
cmp <(python3 -c'print("A"*4000)' | ./notify -provider-config $provider_invalid_webhook -silent -bulk) \
    <(python3 -c'print("A"*4000)') && echo matches
cmp <(python3 -c'print("A"*4000)' | ./notify -provider-config $provider_invalid_webhook -silent) \
    <(python3 -c'print("A"*4000)') && echo matches

heading 'A*4001'
cmp <(python3 -c'print("A"*4001)' | ./notify -provider-config $provider_invalid_webhook -silent -bulk) \
    <(python3 -c'import textwrap; print("...\n".join(textwrap.wrap("A"*4001, width=4000-3)))') && echo matches
cmp <(python3 -c'print("A"*4001)' | ./notify -provider-config $provider_invalid_webhook -silent) \
    <(python3 -c'import textwrap; print("...\n".join(textwrap.wrap("A"*4001, width=4000-3)))') && echo matches

heading 'A*4096'
cmp <(python3 -c'print("A"*4096)' | ./notify -provider-config $provider_invalid_webhook -silent -bulk) \
    <(python3 -c'import textwrap; print("...\n".join(textwrap.wrap("A"*4096, width=4000-3)))') && echo matches
cmp <(python3 -c'print("A"*4096)' | ./notify -provider-config $provider_invalid_webhook -silent) \
    <(python3 -c'import textwrap; print("...\n".join(textwrap.wrap("A"*4096, width=4000-3)))') && echo matches

heading 'A*8192'
cmp <(python3 -c'print("A"*8192)' | ./notify -provider-config $provider_invalid_webhook -silent -bulk) \
    <(python3 -c'import textwrap; print("...\n".join(textwrap.wrap("A"*8192, width=4000-3)))') && echo matches
cmp <(python3 -c'print("A"*8192)' | ./notify -provider-config $provider_invalid_webhook -silent) \
    <(python3 -c'import textwrap; print("...\n".join(textwrap.wrap("A"*8192, width=4000-3)))') && echo matches

heading 'Data including a line of 65535 chars'
cmp <(python3 -c'print("AAAA"); print("B"*65535); print("CCCC")' | ./notify -provider-config $provider_invalid_webhook -silent) \
    <(python3 -c'import textwrap; print("AAAA"); print("...\n".join(textwrap.wrap("B"*65535, width=4000-3))); print("CCCC")') && echo matches

heading 'Data including a line of 65536 chars'
cmp <(python3 -c'print("AAAA"); print("B"*65536); print("CCCC")' | ./notify -provider-config $provider_invalid_webhook -silent) \
    <(python3 -c'import textwrap; print("AAAA"); print("...\n".join(textwrap.wrap("B"*65536, width=4000-3))); print("CCCC")') && echo matches

heading 'A line of 40M chars'
junk=$(mktemp)
base64 -w0 /dev/urandom | head -c40M > $junk
cmp <(./notify -provider-config $provider_invalid_webhook -silent -bulk <$junk) \
    <(python3 -c'import textwrap; data = open("'$junk'", "r").read(); print("...\n".join(textwrap.wrap(data, width=4000-3)))') && echo matches
cmp <(./notify -provider-config $provider_invalid_webhook -silent -i $junk) \
    <(python3 -c'import textwrap; data = open("'$junk'", "r").read(); print("...\n".join(textwrap.wrap(data, width=4000-3)))') && echo matches

% cat provider-invalid-webhook.yaml
custom:
  - id: "webhook"
    custom_webook_url: "http://127.0.0.1:1/"
    custom_method: GET
    custom_format: '{{data}}'
    custom_headers: {}
```

## Before #146 

```plain
% git checkout b947254064e6c09d18b56e1064cbcbabb0e21e72
HEAD is now at b947254 chore(deps): bump golang from 1.18.2-alpine to 1.18.3-alpine (#144)

% vim ../../internal/runner/runner.go

[... SNIP fix #134 ...]

% go build .

% ./test.sh
[+] /etc/passwd
matches
matches
[+] /dev/null
matches
matches
[+] A*6 with -char-limit=3 (Expect errors)
...
...
...
[... SNIP ...]
...
...
...
^C...
- Ctrl+C pressed in Terminal
AAAAAA
[+] A*6 with -char-limit=4
AAAAAA
A...
A...
AAAA
[+] A*2048
matches
matches
[+] A*3999
matches
matches
[+] A*4000
matches
matches
[+] A*4001
matches
/dev/fd/63 /dev/fd/62 differ: byte 3998, line 1
[+] A*4096
matches
/dev/fd/63 /dev/fd/62 differ: byte 3998, line 1
[+] A*8192
matches
/dev/fd/63 /dev/fd/62 differ: byte 3998, line 1
[+] Data including a line of 65535 chars
/dev/fd/63 /dev/fd/62 differ: byte 4003, line 2
[+] Data including a line of 65536 chars
cmp: EOF on /dev/fd/63 after byte 5, line 1
[+] A line of 40M chars
cmp: EOF on /dev/fd/63 which is empty
Traceback (most recent call last):
  File "<string>", line 1, in <module>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
% Traceback (most recent call last):
  File "<string>", line 1, in <module>
BrokenPipeError: [Errno 32] Broken pipe
```

## After #146


```plain
% git checkout 173f91472fd73c410969d063776ff1a7224f
d6d1
HEAD is now at 173f914 Fix notify silently fails (#146)

% vim ../../internal/runner/runner.go

[... SNIP fix #134 ...]

% go build .

% ./test.sh
[+] /etc/passwd
cmp: EOF on /dev/fd/63 which is empty
matches
[+] /dev/null
matches
matches
[+] A*6 with -char-limit=3 (Expect errors)
[+] A*6 with -char-limit=4
[+] A*2048
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
[+] A*3999
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
[+] A*4000
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
[+] A*4001
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
[+] A*4096
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
Exception ignored in: <_io.TextIOWrapper name='<stdout>' mode='w' encoding='UTF-8'>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
[+] A*8192
Traceback (most recent call last):
  File "<string>", line 1, in <module>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
Traceback (most recent call last):
  File "<string>", line 1, in <module>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
[+] Data including a line of 65535 chars
Traceback (most recent call last):
  File "<string>", line 1, in <module>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
[+] Data including a line of 65536 chars
Traceback (most recent call last):
  File "<string>", line 1, in <module>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
[+] A line of 40M chars
cmp: EOF on /dev/fd/63 which is empty
Traceback (most recent call last):
  File "<string>", line 1, in <module>
BrokenPipeError: [Errno 32] Broken pipe
cmp: EOF on /dev/fd/63 which is empty
% Traceback (most recent call last):
  File "<string>", line 1, in <module>
BrokenPipeError: [Errno 32] Broken pipe
```

## After this patch

```
% git checkout bugfix/rework-146
Already on 'bugfix/rework-146'
Your branch is up to date with 'justin/bugfix/rework-146'.

% go build .

% ./test.sh
[+] /etc/passwd
matches
matches
[+] /dev/null
matches
matches
[+] A*6 with -char-limit=3 (Expect errors)
[FTL] Could not run notifier: charLimit must be > 3
[FTL] Could not run notifier: charLimit must be > 3
[+] A*6 with -char-limit=4
A...
A...
AAAA
A...
A...
AAAA
[+] A*2048
matches
matches
[+] A*3999
matches
matches
[+] A*4000
matches
matches
[+] A*4001
matches
matches
[+] A*4096
matches
matches
[+] A*8192
matches
matches
[+] Data including a line of 65535 chars
matches
[+] Data including a line of 65536 chars
matches
[+] A line of 40M chars
matches
matches
```