### PR TITLE
Fix typo in `custom_webhook_url` #170

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -29,7 +29,7 @@ jobs:
         env: 
           DISCORD_WEBHOOK_URL: "${{ secrets.DISCORD_WEBHOOK_URL }}"
           SLACK_WEBHOOK_URL: "${{ secrets.SLACK_WEBHOOK_URL }}"
-          CUSTOM_WEBOOK_URL: "${{ secrets.CUSTOM_WEBOOK_URL }}"
+          CUSTOM_WEBHOOK_URL: "${{ secrets.CUSTOM_WEBHOOK_URL }}"
         run: |
           chmod +x action-run.sh
           bash action-run.sh

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ googlechat:
 
 custom:
   - id: webhook
-    custom_webook_url: http://host/api/webhook
+    custom_webhook_url: http://host/api/webhook
     custom_method: GET
     custom_format: '{{data}}'
     custom_headers:

--- a/cmd/integration-test/test-config.yaml
+++ b/cmd/integration-test/test-config.yaml
@@ -15,7 +15,7 @@ telegram:
     telegram_format: "{{data}}"
 custom:
   - id: "custom-integration-test"
-    custom_webook_url: "${CUSTOM_WEBOOK_URL}"
+    custom_webhook_url: "${CUSTOM_WEBHOOK_URL}"
     custom_method: POST
     custom_format: '{{data}}'
     custom_headers: 

--- a/pkg/providers/custom/custom.go
+++ b/pkg/providers/custom/custom.go
@@ -6,11 +6,12 @@ import (
 	"net/http"
 
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/notify/pkg/utils"
 	"github.com/projectdiscovery/notify/pkg/utils/httpreq"
 	"github.com/projectdiscovery/sliceutil"
-	"go.uber.org/multierr"
 )
 
 type Provider struct {
@@ -19,7 +20,7 @@ type Provider struct {
 
 type Options struct {
 	ID               string            `yaml:"id,omitempty"`
-	CustomWebhookURL string            `yaml:"custom_webook_url,omitempty"`
+	CustomWebhookURL string            `yaml:"custom_webhook_url,omitempty"`
 	CustomMethod     string            `yaml:"custom_method,omitempty"`
 	CustomHeaders    map[string]string `yaml:"custom_headers,omitempty"`
 	CustomFormat     string            `yaml:"custom_format,omitempty"`


### PR DESCRIPTION
* [x] TODO @ehsandeep: update the `CUSTOM_WEBOOK_URL` -> `CUSTOM_WEBHOOK_URL` GitHub secret (it cannot be renamed and the old value is not visible, hence probably you'll need to delete and re-create it - ref: https://github.com/projectdiscovery/team-backlogs/issues/207)