### PR TITLE
Use discord username from config

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -19,13 +19,12 @@ jobs:
         with: 
           go-version: 1.18
 
-      - env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          SLACK_WEBHOOK: "${{ secrets.RELEASE_SLACK_WEBHOOK }}"
-
       - name: "Create release on GitHub"
         uses: goreleaser/goreleaser-action@v3
         with: 
           args: "release --rm-dist"
           version: latest
           workdir: .
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          SLACK_WEBHOOK: "${{ secrets.RELEASE_SLACK_WEBHOOK }}"

--- a/pkg/providers/discord/discord.go
+++ b/pkg/providers/discord/discord.go
@@ -2,6 +2,7 @@ package discord
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/containrrr/shoutrrr"
 	"github.com/oriser/regroup"
@@ -51,7 +52,9 @@ func (p *Provider) Send(message, CliFormat string) error {
 		}
 
 		webhookID, webhookToken := matchedGroups["webhook_identifier"], matchedGroups["webhook_token"]
-		url := fmt.Sprintf("discord://%s@%s?splitlines=no", webhookToken, webhookID)
+		url := fmt.Sprintf("discord://%s@%s?splitlines=no&username=%s", webhookToken, webhookID, 
+								url.QueryEscape(pr.DiscordWebHookUsername))
+		
 		sendErr := shoutrrr.Send(url, msg)
 		if sendErr != nil {
 			sendErr = errors.Wrap(sendErr, fmt.Sprintf("failed to send discord notification for id: %s ", pr.ID))


### PR DESCRIPTION
I was a bit confused when I noticed the `discord_username` parameter in the Discord provider-config.yml file was not actually used when sending the webhook message. It is saved in the `Options` struct here:

```go
type Options struct {
	ID                      string `yaml:"id,omitempty"`
	DiscordWebHookURL       string `yaml:"discord_webhook_url,omitempty"`
	DiscordWebHookUsername  string `yaml:"discord_username,omitempty"`
	DiscordWebHookAvatarURL string `yaml:"discord_avatar,omitempty"`
	DiscordFormat           string `yaml:"discord_format,omitempty"`
}
```

But this `DiscordWebHookUsername` is not actually used further on in the code. This commit simply adds an `&username=` parameter to the `shoutrrr` discord URL that is created and makes sure to escape it to allow special characters in the username. 

```go
url := fmt.Sprintf("discord://%s@%s?splitlines=no&username=%s", webhookToken, webhookID, 
			url.QueryEscape(pr.DiscordWebHookUsername))
		
sendErr := shoutrrr.Send(url, msg)
```

> **Note**: This is my first time writing anything in go, but it's a pretty simple change, so it's probably fine

## Example

![image](https://user-images.githubusercontent.com/26067369/221403672-2ebad928-e42a-4f69-8c36-4b2414407fe1.png)
