### PR TITLE
Gotify support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ teams:
     teams_webhook_url: "https://<domain>.webhook.office.com/webhookb2/xx@xx/IncomingWebhook/xx"
     teams_format: "{{data}}"
 
+gotify:
+  - id: 'gotify'
+    gotify_host: 'XXXXXX'
+    gotify_port: '80'
+    gotify_token: 'XXXXXX'
+    gotify_format: '{{data}}'
+    gotify_disabletls: false
+    gotify_title: "recon"
+
 custom:
   - id: webhook
     custom_webhook_url: http://host/api/webhook

--- a/cmd/integration-test/integration.go
+++ b/cmd/integration-test/integration.go
@@ -17,13 +17,14 @@ var (
 	success        = aurora.Green("[✓]").String()
 	failed         = aurora.Red("[✘]").String()
 	testCases      = map[string]testutils.TestCase{
-		"discord": &discord{},
-		"slack":   &slack{},
-		"custom":  &custom{},
+		// 		"discord":  &discord{},
+		// 		"slack":    &slack{},
+		// 		"custom":   &custom{},
 		//		"telegram": &telegram{},
 		//		"teams":    &teams{},
 		//		"smtp":     &smtp{},
 		//		"pushover": &pushover{},
+		"gotify": &gotify{},
 	}
 )
 

--- a/cmd/integration-test/integration.go
+++ b/cmd/integration-test/integration.go
@@ -17,9 +17,9 @@ var (
 	success        = aurora.Green("[✓]").String()
 	failed         = aurora.Red("[✘]").String()
 	testCases      = map[string]testutils.TestCase{
-		// 		"discord":  &discord{},
-		// 		"slack":    &slack{},
-		// 		"custom":   &custom{},
+		"discord": &discord{},
+		"slack":   &slack{},
+		"custom":  &custom{},
 		//		"telegram": &telegram{},
 		//		"teams":    &teams{},
 		//		"smtp":     &smtp{},

--- a/cmd/integration-test/providers.go
+++ b/cmd/integration-test/providers.go
@@ -27,24 +27,24 @@ func run(provider string) error {
 	return nil
 }
 
-type discord struct{}
-
-func (h *discord) Execute() error {
-	return run("discord")
-}
-
-type custom struct{}
-
-func (h *custom) Execute() error {
-	return run("custom")
-}
-
-type slack struct{}
-
-func (h *slack) Execute() error {
-	return run("slack")
-}
-
+// type discord struct{}
+//
+// func (h *discord) Execute() error {
+// 	return run("discord")
+// }
+//
+// type custom struct{}
+//
+// func (h *custom) Execute() error {
+// 	return run("custom")
+// }
+//
+// type slack struct{}
+//
+// func (h *slack) Execute() error {
+// 	return run("slack")
+// }
+//
 // type pushover struct{}
 //
 // func (h *pushover) Execute() error {
@@ -68,6 +68,12 @@ func (h *slack) Execute() error {
 // func (h *telegram) Execute() error {
 // 	return run("telegram")
 // }
+
+type gotify struct{}
+
+func (h *gotify) Execute() error {
+	return run("gotify")
+}
 
 func errIncorrectResultsCount(results []string) error {
 	return fmt.Errorf("incorrect number of results %s", strings.Join(results, "\n\t"))

--- a/cmd/integration-test/providers.go
+++ b/cmd/integration-test/providers.go
@@ -27,24 +27,24 @@ func run(provider string) error {
 	return nil
 }
 
-// type discord struct{}
-//
-// func (h *discord) Execute() error {
-// 	return run("discord")
-// }
-//
-// type custom struct{}
-//
-// func (h *custom) Execute() error {
-// 	return run("custom")
-// }
-//
-// type slack struct{}
-//
-// func (h *slack) Execute() error {
-// 	return run("slack")
-// }
-//
+type discord struct{}
+
+func (h *discord) Execute() error {
+	return run("discord")
+}
+
+type custom struct{}
+
+func (h *custom) Execute() error {
+	return run("custom")
+}
+
+type slack struct{}
+
+func (h *slack) Execute() error {
+	return run("slack")
+}
+
 // type pushover struct{}
 //
 // func (h *pushover) Execute() error {

--- a/pkg/providers/gotify/gotify.go
+++ b/pkg/providers/gotify/gotify.go
@@ -2,12 +2,14 @@ package gotify
 
 import (
 	"fmt"
+
 	"github.com/containrrr/shoutrrr"
 	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/notify/pkg/utils"
 	sliceutil "github.com/projectdiscovery/utils/slice"
-	"go.uber.org/multierr"
 )
 
 type Provider struct {

--- a/pkg/providers/gotify/gotify.go
+++ b/pkg/providers/gotify/gotify.go
@@ -1,0 +1,57 @@
+package gotify
+
+import (
+	"fmt"
+	"github.com/containrrr/shoutrrr"
+	"github.com/pkg/errors"
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/notify/pkg/utils"
+	sliceutil "github.com/projectdiscovery/utils/slice"
+	"go.uber.org/multierr"
+)
+
+type Provider struct {
+	Gotify  []*Options `yaml:"gotify,omitempty"`
+	counter int
+}
+
+type Options struct {
+	ID           string `yaml:"id,omitempty"`
+	GotifyHost   string `yaml:"gotify_host,omitempty"`
+	GotifyPort   string `yaml:"gotify_port,omitempty"`
+	GotifyToken  string `yaml:"gotify_token,omitempty"`
+	GotifyFormat string `yaml:"gotify_format,omitempty"`
+}
+
+func New(options []*Options, ids []string) (*Provider, error) {
+	provider := &Provider{}
+
+	for _, o := range options {
+		if len(ids) == 0 || sliceutil.Contains(ids, o.ID) {
+			provider.Gotify = append(provider.Gotify, o)
+		}
+	}
+
+	provider.counter = 0
+
+	return provider, nil
+}
+
+func (p *Provider) Send(message, CliFormat string) error {
+	var GotifyErr error
+	p.counter++
+
+	for _, pr := range p.Gotify {
+		msg := utils.FormatMessage(message, utils.SelectFormat(CliFormat, pr.GotifyFormat), p.counter)
+		url := fmt.Sprintf("gotify://%s:%s/%s", pr.GotifyHost, pr.GotifyPort, pr.GotifyToken)
+		err := shoutrrr.Send(url, msg)
+		if err != nil {
+			err = errors.Wrap(err, fmt.Sprintf("failed to send gotify notification for id: %s ", pr.ID))
+			GotifyErr = multierr.Append(GotifyErr, err)
+			continue
+		}
+		gologger.Verbose().Msgf("gotify notification sent for id: %s", pr.ID)
+	}
+
+	return GotifyErr
+}

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -3,13 +3,13 @@ package providers
 import (
 	"github.com/acarl005/stripansi"
 	"github.com/pkg/errors"
-	"github.com/projectdiscovery/notify/pkg/providers/gotify"
 	"go.uber.org/multierr"
 
 	"github.com/projectdiscovery/gologger"
 	"github.com/projectdiscovery/notify/pkg/providers/custom"
 	"github.com/projectdiscovery/notify/pkg/providers/discord"
 	"github.com/projectdiscovery/notify/pkg/providers/googlechat"
+	"github.com/projectdiscovery/notify/pkg/providers/gotify"
 	"github.com/projectdiscovery/notify/pkg/providers/pushover"
 	"github.com/projectdiscovery/notify/pkg/providers/slack"
 	"github.com/projectdiscovery/notify/pkg/providers/smtp"

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"github.com/acarl005/stripansi"
 	"github.com/pkg/errors"
+	"github.com/projectdiscovery/notify/pkg/providers/gotify"
 	"go.uber.org/multierr"
 
 	"github.com/projectdiscovery/gologger"
@@ -28,6 +29,7 @@ type ProviderOptions struct {
 	Telegram   []*telegram.Options   `yaml:"telegram,omitempty"`
 	GoogleChat []*googlechat.Options `yaml:"googlechat,omitempty"`
 	Custom     []*custom.Options     `yaml:"custom,omitempty"`
+	Gotify     []*gotify.Options     `yaml:"gotify,omitempty"`
 }
 
 // Provider is an interface implemented by providers
@@ -108,6 +110,15 @@ func New(providerOptions *ProviderOptions, options *types.Options) (*Client, err
 		provider, err := custom.New(providerOptions.Custom, options.IDs)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not create custom provider client")
+		}
+		client.providers = append(client.providers, provider)
+	}
+
+	if providerOptions.Gotify != nil && (len(options.Providers) == 0 || sliceutil.Contains(options.Providers, "gotify")) {
+
+		provider, err := gotify.New(providerOptions.Gotify, options.IDs)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not create gotify provider client")
 		}
 		client.providers = append(client.providers, provider)
 	}


### PR DESCRIPTION
Added support for Gotify.

Example provider config info;
```
gotify:
  - id: 'gotify'
    gotify_host: 'XXXXXXX'
    gotify_port: 'XXXXXXX'
    gotify_token: 'XXXXXXX'
    gotify_format: '{{data}}'