### PR TITLE
replace underscore with escaped underscore

### DIFF
--- a/pkg/providers/telegram/telegram.go
+++ b/pkg/providers/telegram/telegram.go
@@ -2,6 +2,7 @@ package telegram
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/containrrr/shoutrrr"
 	"github.com/pkg/errors"
@@ -48,6 +49,7 @@ func (p *Provider) Send(message, CliFormat string) error {
 			pr.TelegramParseMode = "None"
 		}
 		url := fmt.Sprintf("telegram://%s@telegram?channels=%s&parsemode=%s", pr.TelegramAPIKey, pr.TelegramChatID, pr.TelegramParseMode)
+		msg = strings.ReplaceAll(msg, "_", "\\_")
 		err := shoutrrr.Send(url, msg)
 		if err != nil {
 			err = errors.Wrap(err, fmt.Sprintf("failed to send telegram notification for id: %s ", pr.ID))


### PR DESCRIPTION
As stated in this issue #239, when sending a message that has a "_" character in telegram gives an error. This is actually caused by parsing the message as markdown.

Issue has been solved by replacing all occurrences of underscore in string with escaped underscore.