### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Notify supports piping output of any tool or output file and send it to configur
 ### Send notification using piped(stdin) output
 
 ```sh
-subfinder -d hackerone.com | notify
+subfinder -d hackerone.com | notify -bulk
 ```
 
 <h1 align="left">


### PR DESCRIPTION
When running `subfinder -d hackerone.com | notify`, an example of [Send notification using piped(stdin) output](https://github.com/projectdiscovery/notify#send-notification-using-pipedstdin-output), the message is not output at once as shown in the screenshot due to the default setting of "line by line". To reduce confusion, `-bulk` option was added.