### PR TITLE
fix proxy setting when ratelimit is 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This will display help for the tool. Here are all the switches it supports.
 | `-no-color`             | disable colors in output                           | `notify -nc`                          |
 | `-provider-config`      | provider config path                               | `notify -pc provider.yaml`            |
 | `-provider`             | provider to send the notification to (optional)    | `notify -p slack,telegram`            |
-| `-proxy`                | http proxy to use with notify                      | `notify -proxy http://127.0.0.1:8080` |
+| `-proxy`                | http/socks5 proxy to use with notify               | `notify -proxy http://127.0.0.1:8080` |
 | `-rate-limit`           | maximum number of HTTP requests to send per second | `notify -rl 1`                        |
 | `-silent`               | enable silent mode                                 | `notify -silent`                      |
 | `-verbose`              | enable verbose mode                                | `notify -verbose`                     |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This will display help for the tool. Here are all the switches it supports.
 | `-no-color`             | disable colors in output                           | `notify -nc`                          |
 | `-provider-config`      | provider config path                               | `notify -pc provider.yaml`            |
 | `-provider`             | provider to send the notification to (optional)    | `notify -p slack,telegram`            |
-| `-proxy`                | http/socks5 proxy to use with notify               | `notify -proxy http://127.0.0.1:8080` |
+| `-proxy`                | HTTP/SOCKSv5 proxy to use with notify              | `notify -proxy http://127.0.0.1:8080` |
 | `-rate-limit`           | maximum number of HTTP requests to send per second | `notify -rl 1`                        |
 | `-silent`               | enable silent mode                                 | `notify -silent`                      |
 | `-verbose`              | enable verbose mode                                | `notify -verbose`                     |

--- a/cmd/notify/notify.go
+++ b/cmd/notify/notify.go
@@ -63,7 +63,7 @@ func readConfig() {
 	set.BoolVarP(&options.Verbose, "verbose", "v", false, "enable verbose mode")
 	set.BoolVar(&options.Version, "version", false, "display version")
 	set.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable colors in output")
-	set.StringVar(&options.Proxy, "proxy", "", "HTTP Proxy to use with notify")
+	set.StringVar(&options.Proxy, "proxy", "", "http/socks5 proxy to use with notify")
 	set.CallbackVarP(runner.GetUpdateCallback(), "update", "up", "update notify to latest version")
 	set.BoolVarP(&options.DisableUpdateCheck, "disable-update-check", "duc", false, "disable automatic notify update check")
 

--- a/cmd/notify/notify.go
+++ b/cmd/notify/notify.go
@@ -63,7 +63,7 @@ func readConfig() {
 	set.BoolVarP(&options.Verbose, "verbose", "v", false, "enable verbose mode")
 	set.BoolVar(&options.Version, "version", false, "display version")
 	set.BoolVarP(&options.NoColor, "no-color", "nc", false, "disable colors in output")
-	set.StringVar(&options.Proxy, "proxy", "", "http/socks5 proxy to use with notify")
+	set.StringVar(&options.Proxy, "proxy", "", "HTTP/SOCKSv5 proxy to use with notify")
 	set.CallbackVarP(runner.GetUpdateCallback(), "update", "up", "update notify to latest version")
 	set.BoolVarP(&options.DisableUpdateCheck, "disable-update-check", "duc", false, "disable automatic notify update check")
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -78,10 +78,9 @@ func (r *Runner) Run() error {
 		}
 	}
 
+	http.DefaultClient.Transport = defaultTransport
 	if r.options.RateLimit > 0 {
 		http.DefaultClient.Transport = utils.NewThrottledTransport(time.Second, r.options.RateLimit, defaultTransport)
-	} else {
-		http.DefaultClient.Transport = defaultTransport
 	}
 
 	var inFile *os.File

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -80,6 +80,8 @@ func (r *Runner) Run() error {
 
 	if r.options.RateLimit > 0 {
 		http.DefaultClient.Transport = utils.NewThrottledTransport(time.Second, r.options.RateLimit, defaultTransport)
+	} else {
+		http.DefaultClient.Transport = defaultTransport
 	}
 
 	var inFile *os.File


### PR DESCRIPTION
Fix #403 

Changes I make:
1. `defaultTransport` should be used when ratelimit is 0.
2. Add info about notify socks5 proxy support. [net.http.Transport](https://pkg.go.dev/net/http#Transport) supports both http and socks5 proxy. Tested. Really works. 