### PR TITLE
feat: Add Jandi provider to notify

### DIFF
--- a/cmd/integration-test/test-config.yaml
+++ b/cmd/integration-test/test-config.yaml
@@ -47,3 +47,7 @@ gotify:
     gotify_token: "${GOTIFY_APP_TOKEN}"
     gotify_format: "{{data}}"
     gotify_disabletls: true
+jandi:
+  - id: "jandi-integration-test"
+    jandi_webhook_url: "${JANDI_WEBHOOK_URL}"
+    jandi_format: "{{data}}"

--- a/pkg/providers/jandi/jandi.go
+++ b/pkg/providers/jandi/jandi.go
@@ -1,0 +1,52 @@
+package jandi
+
+import (
+	"github.com/oriser/regroup"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
+	"github.com/projectdiscovery/gologger"
+	"github.com/projectdiscovery/notify/pkg/utils"
+	sliceutil "github.com/projectdiscovery/utils/slice"
+)
+
+var reJandiWebhook = regroup.MustCompile(`(?P<scheme>https?):\/\/(?P<domain>(?:ptb\.|canary\.)?Jandi(?:app)?\.com)\/api(?:\/)?(?P<api_version>v\d{1,2})?\/webhooks\/(?P<webhook_identifier>\d{17,19})\/(?P<webhook_token>[\w\-]{68})`)
+
+type Provider struct {
+	Jandi []*Options `yaml:"jandi,omitempty"`
+	counter int
+}
+
+type Options struct {
+	ID              string `yaml:"id,omitempty"`
+	JandiWebHookURL string `yaml:"jandi_webhook_url,omitempty"`
+	JandiFormat     string `yaml:"jandi_format,omitempty"`
+}
+
+func New(options []*Options, ids []string) (*Provider, error) {
+	provider := &Provider{}
+
+	for _, o := range options {
+		if len(ids) == 0 || sliceutil.Contains(ids, o.ID) {
+			provider.Jandi = append(provider.Jandi, o)
+		}
+	}
+
+	provider.counter = 0
+
+	return provider, nil
+}
+func (p *Provider) Send(message, CliFormat string) error {
+	var errs []error
+	for _, pr := range p.Jandi {
+		msg := utils.FormatMessage(message, utils.SelectFormat(CliFormat, pr.JandiFormat), p.counter)
+
+		if err := pr.SendMessage(msg); err != nil {
+			errs = append(errs, errors.Wrapf(err, "failed to send jandi notification for id: %s ", pr.ID))
+			continue
+		}
+
+		gologger.Verbose().Msgf("jandi notification sent for id: %s", pr.ID)
+	}
+	return multierr.Combine(errs...)
+}

--- a/pkg/providers/jandi/jandi_api.go
+++ b/pkg/providers/jandi/jandi_api.go
@@ -1,0 +1,36 @@
+package jandi
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+
+	"github.com/projectdiscovery/notify/pkg/utils/httpreq"
+)
+
+func (options *Options) SendMessage(message string) error {
+	payload := APIRequest{
+		Body: message,
+	}
+
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	body := bytes.NewReader(encoded)
+	req, err := http.NewRequest(http.MethodPost, options.JandiWebHookURL, body)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Accept", "application/vnd.tosslab.jandi-v2+json")
+	req.Header.Set("Content-Type", "application/json")
+
+	_, err = httpreq.NewClient().Do(req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/providers/jandi/jandi_types.go
+++ b/pkg/providers/jandi/jandi_types.go
@@ -1,0 +1,11 @@
+package jandi
+
+type APIRequest struct {
+	Body    string `json:"body"`
+	ConnectInfo   []ConnectInfo `json:"connectInfo,omitempty"`
+}
+
+type ConnectInfo struct {
+	Title string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+}

--- a/pkg/providers/providers.go
+++ b/pkg/providers/providers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/projectdiscovery/notify/pkg/providers/smtp"
 	"github.com/projectdiscovery/notify/pkg/providers/teams"
 	"github.com/projectdiscovery/notify/pkg/providers/telegram"
+	"github.com/projectdiscovery/notify/pkg/providers/jandi"
 	"github.com/projectdiscovery/notify/pkg/types"
 	sliceutil "github.com/projectdiscovery/utils/slice"
 )
@@ -30,6 +31,7 @@ type ProviderOptions struct {
 	GoogleChat []*googlechat.Options `yaml:"googlechat,omitempty"`
 	Custom     []*custom.Options     `yaml:"custom,omitempty"`
 	Gotify     []*gotify.Options     `yaml:"gotify,omitempty"`
+	Jandi      []*jandi.Options      `yaml:"jandi,omitempty"`
 }
 
 // Provider is an interface implemented by providers
@@ -119,6 +121,15 @@ func New(providerOptions *ProviderOptions, options *types.Options) (*Client, err
 		provider, err := gotify.New(providerOptions.Gotify, options.IDs)
 		if err != nil {
 			return nil, errors.Wrap(err, "could not create gotify provider client")
+		}
+		client.providers = append(client.providers, provider)
+	}
+
+	if providerOptions.Jandi != nil && (len(options.Providers) == 0 || sliceutil.Contains(options.Providers, "jandi")) {
+
+		provider, err := jandi.New(providerOptions.Jandi, options.IDs)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not create jandi provider client")
 		}
 		client.providers = append(client.providers, provider)
 	}


### PR DESCRIPTION
Hello ProjectDiscovery,

I’d like to submit this Pull Request to add a Jandi Provider to the notify project.
[Jandi](https://www.jandi.com/landing/en) is a collaboration and communication platform that helps teams manage projects more efficiently.


[Jandi_Incoming-Webhook](https://support.jandi.com/en/articles/%EC%9E%94%EB%94%94-%EC%BB%A4%EB%84%A5%ED%8A%B8-%EC%9D%B8%EC%BB%A4%EB%B0%8D-%EC%9B%B9%ED%9B%85Incoming-Webhook%EC%9C%BC%EB%A1%9C-%EC%99%B8%EB%B6%80-%EB%8D%B0%EC%9D%B4%ED%84%B0%EB%A5%BC-%EC%9E%94%EB%94%94%EB%A1%9C-%EC%88%98%EC%8B%A0%ED%95%98%EA%B3%A0-%EC%8B%B6%EC%8A%B5%EB%8B%88%EB%8B%A4-56bacd47)

Please feel free to let me know if there’s anything I can improve or if you have any feedback. Thank you!

<img width="667" alt="스크린샷 2025-01-16 오전 1 41 47" src="https://github.com/user-attachments/assets/bda1361f-16f0-4b66-bfd5-af1999a465ac" />
<img width="354" alt="스크린샷 2025-01-16 오전 1 42 11" src="https://github.com/user-attachments/assets/63cafcac-2ef3-48ac-9fa1-ce518a72d1ab" />
