### PR TITLE
Slack Provider: Fixes slack_username and adds slack_icon_emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,14 @@ slack:
     slack_channel: "recon"
     slack_username: "test"
     slack_format: "{{data}}"
+    slack_icon_emoji: ":ghost:"
     slack_webhook_url: "https://hooks.slack.com/services/XXXXXX"
 
   - id: "vulns"
     slack_channel: "vulns"
     slack_username: "test"
     slack_format: "{{data}}"
+    slack_icon_emoji: ":ghost:"
     slack_webhook_url: "https://hooks.slack.com/services/XXXXXX"
 
 discord:

--- a/pkg/providers/slack/slack.go
+++ b/pkg/providers/slack/slack.go
@@ -1,11 +1,12 @@
 package slack
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
-	"net/url"
+	"net/http"
 	"strings"
 
-	"github.com/containrrr/shoutrrr"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
@@ -28,6 +29,7 @@ type Options struct {
 	SlackThreadTS   string `yaml:"slack_thread_ts,omitempty"`
 	SlackToken      string `yaml:"slack_token,omitempty"`
 	SlackFormat     string `yaml:"slack_format,omitempty"`
+	SlackIconEmoji  string `yaml:"slack_icon_emoji,omitempty"`
 }
 
 func New(options []*Options, ids []string) (*Provider, error) {
@@ -50,6 +52,7 @@ func (p *Provider) Send(message, CliFormat string) error {
 	for _, pr := range p.Slack {
 		msg := utils.FormatMessage(message, utils.SelectFormat(CliFormat, pr.SlackFormat), p.counter)
 
+		// Handle threaded messages separately
 		if pr.SlackThreads {
 			if pr.SlackToken == "" {
 				err := errors.Wrap(fmt.Errorf("slack_token value is required to start a thread"),
@@ -70,22 +73,37 @@ func (p *Provider) Send(message, CliFormat string) error {
 				continue
 			}
 		} else {
-			slackTokens := strings.TrimPrefix(pr.SlackWebHookURL, "https://hooks.slack.com/services/")
-			url := &url.URL{
-				Scheme: "slack",
-				Path:   slackTokens,
-			}
-
-			query := url.Query()
-			if pr.SlackUsername != "" {
-				query.Set("username", pr.SlackUsername)
-			}
-			url.RawQuery = query.Encode()
-
-			err := shoutrrr.Send(url.String(), msg)
-			if err != nil {
-				err = errors.Wrap(err,
+			// Send via webhook with emoji and username
+			if !strings.HasPrefix(pr.SlackWebHookURL, "https://hooks.slack.com/services/") {
+				err := errors.Wrap(fmt.Errorf("invalid slack webhook URL"),
 					fmt.Sprintf("failed to send slack notification for id: %s ", pr.ID))
+				SlackErr = multierr.Append(SlackErr, err)
+				continue
+			}
+
+			payload := map[string]interface{}{
+				"text": msg,
+			}
+			if pr.SlackUsername != "" {
+				payload["username"] = pr.SlackUsername
+			}
+			if pr.SlackIconEmoji != "" {
+				payload["icon_emoji"] = pr.SlackIconEmoji
+			}
+
+			jsonPayload, err := json.Marshal(payload)
+			if err != nil {
+				err = errors.Wrap(err, fmt.Sprintf("failed to marshal Slack payload for id: %s", pr.ID))
+				SlackErr = multierr.Append(SlackErr, err)
+				continue
+			}
+
+			resp, err := http.Post(pr.SlackWebHookURL, "application/json", bytes.NewBuffer(jsonPayload))
+			if err != nil || resp.StatusCode >= 400 {
+				if err == nil {
+					err = fmt.Errorf("received non-success status: %s", resp.Status)
+				}
+				err = errors.Wrap(err, fmt.Sprintf("failed to send slack notification for id: %s", pr.ID))
 				SlackErr = multierr.Append(SlackErr, err)
 				continue
 			}

--- a/pkg/providers/slack/slack.go
+++ b/pkg/providers/slack/slack.go
@@ -76,6 +76,12 @@ func (p *Provider) Send(message, CliFormat string) error {
 				Path:   slackTokens,
 			}
 
+			query := url.Query()
+			if pr.SlackUsername != "" {
+				query.Set("username", pr.SlackUsername)
+			}
+			url.RawQuery = query.Encode()
+
 			err := shoutrrr.Send(url.String(), msg)
 			if err != nil {
 				err = errors.Wrap(err,
@@ -85,7 +91,6 @@ func (p *Provider) Send(message, CliFormat string) error {
 			}
 		}
 		gologger.Verbose().Msgf("Slack notification sent for id: %s", pr.ID)
-
 	}
 	return SlackErr
 }

--- a/pkg/providers/slack/slack.go
+++ b/pkg/providers/slack/slack.go
@@ -99,11 +99,14 @@ func (p *Provider) Send(message, CliFormat string) error {
 			}
 
 			resp, err := http.Post(pr.SlackWebHookURL, "application/json", bytes.NewBuffer(jsonPayload))
-			if err != nil || resp.StatusCode >= 400 {
-				if err == nil {
-					err = fmt.Errorf("received non-success status: %s", resp.Status)
-				}
+			if err != nil {
 				err = errors.Wrap(err, fmt.Sprintf("failed to send slack notification for id: %s", pr.ID))
+				SlackErr = multierr.Append(SlackErr, err)
+				continue
+			}
+			resp.Body.Close()
+			if resp.StatusCode >= 400 {
+				err = errors.Wrap(fmt.Errorf("received non-success status: %s", resp.Status), fmt.Sprintf("failed to send slack notification for id: %s", pr.ID))
 				SlackErr = multierr.Append(SlackErr, err)
 				continue
 			}


### PR DESCRIPTION
Hi, this PR fixes and implements the use of the `slack_username` configuration, which was previously non-functional.

I'm also adding `slack_icon_emoji`, which sets the emoji for the username. When adding this, I noticed that shoutrrr does not support setting icon_emoji in Slack messages.

Slack expects the icon_emoji to be included in the JSON payload of the POST request, but shoutrrr only supports basic message text and allows the username through a query parameter — it does not permit modifying the JSON payload structure to include icon_emoji.

To fully support both username and emoji, I replaced the shoutrrr.Send() call with a simple http.Post using a custom JSON payload. This provides complete control and ensures compatibility with Slack’s webhook API.

I hope this is okay. If not, I can leave the `slack_icon_emoji` out of this PR and revert to the shoutrrr implementation, but at least it will make the `slack_username` work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing the Slack message icon using an emoji for notifications.

* **Documentation**
  * README example configuration now shows how to set a custom emoji icon for Slack provider entries.

* **Bug Fixes / Reliability**
  * Improved webhook validation and error handling for Slack notifications to reduce delivery failures and provide clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->