### PR TITLE
Disable Telegram Link Previews by Default

### DIFF
--- a/pkg/providers/telegram/telegram.go
+++ b/pkg/providers/telegram/telegram.go
@@ -47,7 +47,7 @@ func (p *Provider) Send(message, CliFormat string) error {
 		if pr.TelegramParseMode == "" {
 			pr.TelegramParseMode = "None"
 		}
-		url := fmt.Sprintf("telegram://%s@telegram?channels=%s&parsemode=%s", pr.TelegramAPIKey, pr.TelegramChatID, pr.TelegramParseMode)
+		url := fmt.Sprintf("telegram://%s@telegram?channels=%s&parsemode=%s&preview=No", pr.TelegramAPIKey, pr.TelegramChatID, pr.TelegramParseMode)
 		err := shoutrrr.Send(url, msg)
 		if err != nil {
 			err = errors.Wrap(err, fmt.Sprintf("failed to send telegram notification for id: %s ", pr.ID))


### PR DESCRIPTION
It would be better to disable telegram link previews by default for various privacy & security reasons.

Reference:

https://github.com/containrrr/shoutrrr/blob/main/docs/services/telegram.md#optional-parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram notifications now have link previews disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->