### PR TITLE
Add HTTP client timeout for webhook requests

### DIFF
--- a/pkg/utils/httpreq/httpreq.go
+++ b/pkg/utils/httpreq/httpreq.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	jsoniter "github.com/json-iterator/go"
 )
@@ -13,9 +14,14 @@ type Client struct {
 	httpClient *http.Client
 }
 
+const defaultTimeout = 10 * time.Second
+
 func NewClient() *Client {
 	return &Client{
-		httpClient: http.DefaultClient,
+		httpClient: &http.Client{
+			Transport: http.DefaultClient.Transport,
+			Timeout:   defaultTimeout,
+		},
 	}
 }
 


### PR DESCRIPTION
Closes #533

Adds a 10s timeout to the shared HTTP client used by all webhook providers (Slack, Discord, Notion, Custom).