### PR TITLE
Document Rocket.Chat provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Notify is a Go-based assistance package that enables you to stream the output of
 
 - Supports for Slack / Discord / Telegram
 - Supports for Pushover / Email
-- Supports for Microsoft Teams / Google Chat
+- Supports for Microsoft Teams / Google Chat / Rocket.Chat
 - Supports for File / Pipe input
 - Supports Line by Line / Bulk Post
 - Supports using Single / Multiple providers
@@ -160,6 +160,15 @@ gotify:
     gotify_disabletls: false
     gotify_title: "recon"
 
+rocketchat:
+  - id: "soc"
+    rocketchat_webhook_url: "https://chat.example.com/hooks/XXXXXXXX"
+    rocketchat_channel: "#alertas-seguranca"
+    rocketchat_username: "ProjectDiscovery"
+    rocketchat_avatar: "https://example.com/avatar.png"
+    rocketchat_emoji: ":ghost:"
+    rocketchat_format: "{{data}}"
+
 custom:
   - id: webhook
     custom_webhook_url: http://host/api/webhook
@@ -265,5 +274,6 @@ Notify flags can be configured at default config (`$HOME/.config/notify/config.y
 - [Creating Discord webhook](https://support.discord.com/hc/en-us/articles/228383668-Intro-to-Webhooks)
 - [Creating Telegram bot](https://core.telegram.org/bots#3-how-do-i-create-a-bot)
 - [Creating Pushover Token](https://github.com/containrrr/shoutrrr/blob/main/docs/services/pushover.md)
+- [Creating Rocket.Chat Incoming Webhook](https://docs.rocket.chat/docs/integrations#incoming-webhook-script)
 
 Notify is made with 🖤 by the [projectdiscovery](https://projectdiscovery.io) team.

--- a/cmd/integration-test/providers.go
+++ b/cmd/integration-test/providers.go
@@ -75,6 +75,12 @@ func (h *gotify) Execute() error {
 	return run("gotify")
 }
 
+// type rocketchat struct{}
+//
+// func (h *rocketchat) Execute() error {
+// 	return run("rocketchat")
+// }
+
 func errIncorrectResultsCount(results []string) error {
 	return fmt.Errorf("incorrect number of results %s", strings.Join(results, "\n\t"))
 }

--- a/cmd/integration-test/test-config.yaml
+++ b/cmd/integration-test/test-config.yaml
@@ -47,3 +47,9 @@ gotify:
     gotify_token: "${GOTIFY_APP_TOKEN}"
     gotify_format: "{{data}}"
     gotify_disabletls: true
+rocketchat:
+  - id: "rocketchat-integration-test"
+    rocketchat_webhook_url: "${ROCKETCHAT_WEBHOOK_URL}"
+    rocketchat_channel: "random"
+    rocketchat_username: "test"
+    rocketchat_format: "{{data}}"


### PR DESCRIPTION
## Summary
- Documents the `rocketchat` provider in the README (features list, provider config example, webhook reference link)
- Adds a `rocketchat` entry to the integration-test config, commented out in `providers.go` following the existing pattern for teams/telegram (no webhook secret configured in CI yet)

Depends on #545 for the provider implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rocket.Chat to the list of supported providers.
  * Added a Rocket.Chat configuration example and linked to incoming webhook documentation.

* **Documentation**
  * Expanded provider setup guidance for Rocket.Chat.
  * Added placeholder integration notes for future Rocket.Chat support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->